### PR TITLE
Use 'use x' instead of 'use namespace x'

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -6,10 +6,10 @@ rem Path to the library folder
 set LIB=%OSP%\lib
 
 echo [!] Compiling osprey.interpreter...
-%OSPC% /libpath "%LIB%" /verbose /type module /out "%LIB%\osprey.interpreter\osprey.interpreter.ovm" /name osprey.interpreter /doc "%LIB%\osprey.interpreter\osprey.interpreter.ovm.json" /formatjson osprey.interpreter\osprey.interpreter.osp
+%OSPC% /libpath "%LIB%" /import osprey.compiler /verbose /type module /out "%LIB%\osprey.interpreter\osprey.interpreter.ovm" /name osprey.interpreter /doc "%LIB%\osprey.interpreter\osprey.interpreter.ovm.json" /formatjson osprey.interpreter\osprey.interpreter.osp
 
 if %ERRORLEVEL%==0 (
 	echo.
 	echo [!] Compiling ospi...
-	%OSPC% /libpath "%LIB%" /verbose /main osprey.interpreter.main /out bin\ospi.ovm /name ospi /doc bin\ospi.ovm.json /formatjson ospi\ospi.osp
+	%OSPC% /libpath "%LIB%" /import osprey.compiler /import osprey.interpreter /verbose /main osprey.interpreter.main /out bin\ospi.ovm /name ospi /doc bin\ospi.ovm.json /formatjson ospi\ospi.osp
 )

--- a/ospi/App.osp
+++ b/ospi/App.osp
@@ -1,7 +1,7 @@
-use namespace aves;
-use namespace osprey.compiler;
-use namespace osprey.compiler.parser;
-use namespace osprey.compiler.syntax;
+use aves;
+use osprey.compiler;
+use osprey.compiler.parser;
+use osprey.compiler.syntax;
 
 namespace osprey.interpreter;
 

--- a/ospi/InterpreterErrorManager.osp
+++ b/ospi/InterpreterErrorManager.osp
@@ -1,5 +1,5 @@
-use namespace aves;
-use namespace osprey.compiler;
+use aves;
+use osprey.compiler;
 
 namespace osprey.interpreter;
 

--- a/ospi/SyntaxPrinter.osp
+++ b/ospi/SyntaxPrinter.osp
@@ -1,8 +1,8 @@
-use namespace aves;
-use namespace aves.reflection;
-use namespace osprey.compiler;
-use namespace osprey.compiler.parser;
-use namespace osprey.compiler.syntax;
+use aves;
+use aves.reflection;
+use osprey.compiler;
+use osprey.compiler.parser;
+use osprey.compiler.syntax;
 
 namespace osprey.interpreter;
 

--- a/ospi/ospi.osp
+++ b/ospi/ospi.osp
@@ -1,6 +1,3 @@
-use osprey.compiler;
-use osprey.interpreter;
-
 use "App.osp";
 use "InterpreterErrorManager.osp";
 use "SyntaxPrinter.osp";

--- a/osprey.interpreter/CommandParser.osp
+++ b/osprey.interpreter/CommandParser.osp
@@ -1,7 +1,7 @@
-use namespace aves;
-use namespace osprey.compiler;
-use namespace osprey.compiler.parser;
-use namespace osprey.compiler.syntax;
+use aves;
+use osprey.compiler;
+use osprey.compiler.parser;
+use osprey.compiler.syntax;
 
 namespace osprey.interpreter;
 

--- a/osprey.interpreter/osprey.interpreter.osp
+++ b/osprey.interpreter/osprey.interpreter.osp
@@ -1,3 +1,1 @@
-use osprey.compiler;
-
 use "CommandParser.osp";


### PR DESCRIPTION
osprey-lang/ospc#1 and osprey-lang/osprey#1 change the 'use namespace x' syntax to just 'use x', which naturally breaks a lot of source files. Update source files.